### PR TITLE
Switch back to latest react-native-fast-crypto

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "create-hash": "^1.1.0",
-    "@celo/react-native-fast-crypto": "^1.8.4",
+    "react-native-fast-crypto": "^2.0.0",
     "react-native-securerandom": "1.0.0",
     "unorm": "^1.3.3"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 var unorm = require("unorm");
 var assert = require("assert");
-var pbkdf2 = require("@celo/react-native-fast-crypto").pbkdf2;
+var pbkdf2 = require("react-native-fast-crypto").pbkdf2;
 var createHash = require("create-hash");
 import { generateSecureRandom } from "react-native-securerandom";
 


### PR DESCRIPTION
Valora's Android `minSdkVersion` is now `21` so we can switch to the latest `react-native-fast-crypto` instead of our fork.
Also it now uses `OpenSSL-Universal` on iOS instead of bundling its own openssl lib which fixes compatibility issues with Flipper.